### PR TITLE
supports building with locally built packages

### DIFF
--- a/local.sh
+++ b/local.sh
@@ -11,13 +11,11 @@ if [ ! -d "${SOURCE_REPO_DIR}" ]; then
     exit 0
 fi
 
-if [ ! -d "${SOURCE_REPO_DIR}/${XCF_OUTPUT_DIR}" ]; then
-    # builds packages and produces XCF files
-    pushd .
-    cd "${SOURCE_REPO_DIR}"
-    python3 ./CircleciScripts/create_xcframeworks.py
-    popd
-fi
+# builds packages and produces XCF files
+pushd .
+cd "${SOURCE_REPO_DIR}"
+python3 ./CircleciScripts/create_xcframeworks.py
+popd
 
 if [ ! -d "XCF" ]; then
     # Copy XCF output into SPM repo


### PR DESCRIPTION
*Issue #, if available:*

#32 

*Description of changes:*

Working with Amplify or any other package which consumes this SPM package cannot work with modified AWS SDK code unless it can be referenced in local XCF files. This update allows for referencing files place an a folder named XCF. The script `local.sh` runs the build with `aws-sdk-ios` being placed in the same directory as this repo.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
