### PR TITLE
chore: Remove the step to sync release branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,14 +52,6 @@ jobs:
             release_version=$(cat Package.swift | grep -o -E '([0-9]+)\.([0-9]+)\.([0-9]+)')
             echo "export release_version=$release_version" >> $BASH_ENV
       - run:
-          name: Reset the release branch to main
-          command: |
-            git fetch origin main
-            git checkout release
-            git reset --hard main
-            git push -f https://${GITHUB_SPM_RELEASE_TOKEN}@github.com/aws-amplify/aws-sdk-ios-spm.git
-            echo "Reset complete"
-      - run:
           name: Update tag
           command: |
             echo $release_version


### PR DESCRIPTION
*Description of changes:* This change removes a step that syncs `release` branch with `main` from the release pipeline. We do not need to keep release and main sync and developers can use main branch directly. Removing this step should fix one of the CircleCI error that happens during release.
https://app.circleci.com/pipelines/github/aws-amplify/aws-sdk-ios-spm/152/workflows/e2189f72-7073-443a-86e3-d8eb016f9a2c/jobs/132


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
