### PR TITLE
chore: Updating xcode version for CircleCI [skip ci]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 
 defaults: &defaults
   macos:
-    xcode: '12.0.0'
+    xcode: '13.2.1'
   working_directory: ~/aws-sdk-ios-spm
 
 references:


### PR DESCRIPTION
*Description of changes:*
Bumping Xcode version to 13.2.1, as 12.0.0 is no longer supported

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
