### PR TITLE
fix: Replace deprecated flag for the copy operation

### DIFF
--- a/local.sh
+++ b/local.sh
@@ -22,7 +22,7 @@ popd
 
 # Copy XCF output into SPM repo
 mkdir -p XCF
-cp -rp "${SOURCE_REPO_DIR}/${XCF_OUTPUT_DIR}" .
+cp -Rp "${SOURCE_REPO_DIR}/${XCF_OUTPUT_DIR}" .
 
 # Manually enable local repo when it is being used locally
 echo "Update ${XCF_OUTPUT_DIR}/Package.swift to use local XCF files"


### PR DESCRIPTION
fixes #69

A fix to replace usage of discouraged flag.

_There is no 'develop' branch. Excuse me for pulling into `main` if I'm doing it too early after opening the issue._